### PR TITLE
Update Import-XrmSolution.ps1

### DIFF
--- a/src/Solutions/Import-XrmSolution.ps1
+++ b/src/Solutions/Import-XrmSolution.ps1
@@ -95,7 +95,7 @@ function Import-XrmSolution {
         $importSolutionRequest | Add-XrmRequestParameter -Name "ConvertToManaged" -Value $ConvertToManaged | Out-Null;
         $importSolutionRequest | Add-XrmRequestParameter -Name "SkipProductUpdateDependencies" -Value $SkipProductUpdateDependencies | Out-Null;
         if ($Upgrade -or $StageForUpgrade) {
-            $importSolutionRequest | Add-XrmRequestParameter -Name "HoldingSolution" -Value $Upgrade | Out-Null;
+            $importSolutionRequest | Add-XrmRequestParameter -Name "HoldingSolution" -Value $true | Out-Null;
         }
 
         try {            

--- a/src/Solutions/Import-XrmSolution.ps1
+++ b/src/Solutions/Import-XrmSolution.ps1
@@ -24,10 +24,13 @@
     Direct the system to convert any matching unmanaged customizations into your managed solution. (Default : false)
 
     .PARAMETER Upgrade
-    Gets or sets whether to import the solution as a holding solution staged for upgrade. (Default : false)
+    Gets or sets whether to import the solution as a holding solution with immediate application of the upgrade. (Default : false)
 
     .PARAMETER SkipProductUpdateDependencies
     Gets or sets whether enforcement of dependencies related to product updates should be skipped. (Default : false)
+    
+    .PARAMETER StageForUpgrade
+    Gets or sets whether to import the solution as a holding solution without immediate application of the upgrade. The upgrade can afterwards be triggered with Start-XrmSolutionUpgrade. This parameter is ignored if 'Upgrade' already is set to true. (Default : false)
 #>
 function Import-XrmSolution {
     [CmdletBinding()]
@@ -67,6 +70,10 @@ function Import-XrmSolution {
         [Parameter(Mandatory = $false)]
         [Boolean]
         $SkipProductUpdateDependencies = $true
+        
+        [Parameter(Mandatory = $false)]
+        [Boolean]
+        $StageForUpgrade = $false,
     )
     begin {   
         $StopWatch = [System.Diagnostics.Stopwatch]::StartNew(); 
@@ -87,7 +94,7 @@ function Import-XrmSolution {
         $importSolutionRequest | Add-XrmRequestParameter -Name "OverwriteUnmanagedCustomizations" -Value $OverwriteUnmanagedCustomizations | Out-Null;
         $importSolutionRequest | Add-XrmRequestParameter -Name "ConvertToManaged" -Value $ConvertToManaged | Out-Null;
         $importSolutionRequest | Add-XrmRequestParameter -Name "SkipProductUpdateDependencies" -Value $SkipProductUpdateDependencies | Out-Null;
-        if ($Upgrade) {
+        if ($Upgrade -or $StageForUpgrade) {
             $importSolutionRequest | Add-XrmRequestParameter -Name "HoldingSolution" -Value $Upgrade | Out-Null;
         }
 


### PR DESCRIPTION
In some cases you want to first import solutions and only apply them later on using Start-XrmSolutionUpgrade. This is in the event of removal of entities in the newer version where other solutions are still depending on. 

When you import manually in power platform, you can choose for 'Upgrade' or 'Stage for upgrade'. Adding the parameter 'StageForUpgrade' to this script also gives you this option using scripting.

![image](https://user-images.githubusercontent.com/46420661/195323508-71459fd6-33ce-4a5f-938a-4ab8f2660ddf.png)
