### PR TITLE
Upsert-XrmAssembly function fix

### DIFF
--- a/src/Plugins/Upsert-XrmAssembly.ps1
+++ b/src/Plugins/Upsert-XrmAssembly.ps1
@@ -54,7 +54,7 @@ function Upsert-XrmAssembly {
     process {
         
         $assemblyFile = [System.Reflection.Assembly]::Load([System.IO.File]::ReadAllBytes($AssemblyPath));
-        $assemblyProperties = $assemblyFile.GetName().FullName.Split(",= ".ToCharArray(), [StringSplitOptions]::RemoveEmptyEntries);
+        $assemblyProperties = $assemblyFile.GetName().FullName.Split(",=".ToCharArray(), [StringSplitOptions]::RemoveEmptyEntries) | ForEach-Object { $_.Trim() };
         $assemblyShortName = $assemblyProperties[0];
         $assemblyContent = Get-XrmBase64 -FilePath $AssemblyPath;
 


### PR DESCRIPTION
Fix assembly properties parsing in Upsert-XrmAssembly function to support assembly names with spaces. 

With original implementation assemlies like "My Plugin Assembly.dll" were incorrectly parsed into array of name, version, culture and publickeytoken.